### PR TITLE
[Issue-9] Thrown RuntimeException when fails to initialize Aphrodite

### DIFF
--- a/src/main/java/org/jboss/set/cryo/Cryo.java
+++ b/src/main/java/org/jboss/set/cryo/Cryo.java
@@ -253,8 +253,8 @@ public class Cryo {
             return true;
         } catch (AphroditeException e) {
             Main.log("Failed to initialize aphrodite!", e);
+            throw new RuntimeException("Failed to initialize aphrodite!", e);
         }
-        return false;
     }
 
     /**


### PR DESCRIPTION
Fixes #9 

Although Cryo jobs failed to initialize the Aphrodite instance all the time recently, the jobs indicate `success` instead of `failure`.

I believe it is better to re-thrown the exception out to reflect the real problem.

I don't think re-trying to initialize the Aphrodite instance in cryo some day is a good approach, it is much easier to just re-trigger the job in that case IMO :)